### PR TITLE
fix setting log level in web interface does not work

### DIFF
--- a/usr/share/openmediavault/mkconf/minidlna
+++ b/usr/share/openmediavault/mkconf/minidlna
@@ -88,7 +88,7 @@ notify_interval=60
 serial=31446138
 model_number=1
 ${rootcontainer}
-log_level=${log_level}
+log_level=general,artwork,database,inotify,scanner,metadata,http,ssdp,tivo=${log_level}
 ${extraoptions}
 EOF
 


### PR DESCRIPTION
I find out it does not work when I set log level in openmediavault web interface. I check the manual (man minidlna.conf) and find out these:

log_level
  Set  this	 to  change  the  verbosity of the information that is
  logged each section can  use  a  different  level:  off,	fatal,
  error, warn, info, or debug

  Example
  log_level=general,artwork,database,inotify,scanner,metadata,http,ssdp,tivo=warn

Then I check the source code of minidlna (https://sourceforge.net/projects/minidlna), and find the log_init function in log.c file. If we do not set following the above format, the log level will be set to default (warn).